### PR TITLE
Piston bastion fix

### DIFF
--- a/Bastion/src/isaac/bastion/manager/BastionBlockManager.java
+++ b/Bastion/src/isaac/bastion/manager/BastionBlockManager.java
@@ -38,6 +38,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Dispenser;
 
 import com.untamedears.citadel.Citadel;
+import com.untamedears.citadel.entity.Faction;
 import com.untamedears.citadel.entity.PlayerReinforcement;
 
 
@@ -295,12 +296,34 @@ public class BastionBlockManager
 		if(blocking.size() != 0)
 			event.setCancelled(true);
 	}
+	
 	public void handlePistonPush(BlockPistonExtendEvent event) {
 		Set<BastionBlock> blocking = shouldStopBlock(null,new HashSet<Block>(event.getBlocks()), null);
+		BlockFace direction=event.getDirection();
+		Block pistonBlock=event.getBlock(); //Get the block representing the piston
+
+		Block pistonArm=pistonBlock.getRelative(direction);
+
+		PlayerReinforcement pistonReinforcement = (PlayerReinforcement) Citadel.getReinforcementManager().
+				getReinforcement(pistonBlock);
+
+		Faction pistonGroup=null;
+		String foundersName=null;
+
+		if(pistonReinforcement instanceof PlayerReinforcement){ //get the owner of the piston's name if we can
+			pistonGroup=pistonReinforcement.getOwner();
+			foundersName=pistonGroup.getFounder();
+		}
+
+		Set<Block> blocks = new HashSet<Block>();
+		blocks.add(pistonArm);
+		blocks.addAll(event.getBlocks());
 		
-		if(blocking.size() != 0)
+		if(shouldStopBlock(null, blocks, foundersName).size() > 0){
 			event.setCancelled(true);
+		}
 	}
+	
 	public void handleBucketPlace(PlayerBucketEmptyEvent event) {
 		Set<Block> blocks = new HashSet<Block>();
 		blocks.add(event.getBlockClicked().getRelative(event.getBlockFace()));


### PR DESCRIPTION
A fix for the piston bastion issues noted at http://www.reddit.com/r/Civcraft/comments/28j5oq/bastion_fields_and_pistons/ . Re-adds the ability for pistons to push unreinforced blocks within a bastion field if they are either:
- Group reinforced to the same group as the bastion.
- Privately reinforced, and the owner is a member of the bastion group.

_Please note that due to citadel API issues (wrong version?) I can't compile Bastion mod at all._ Will need to get another dev to review & compile (good idea anyway).
